### PR TITLE
Upload versioned wheels to PyPI

### DIFF
--- a/.github/workflows/make_wheel.yml
+++ b/.github/workflows/make_wheel.yml
@@ -41,36 +41,46 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { name: 'Linux LLVM+libstdc++', os: 'ubuntu-22.04', platform: 'manylinux_2_35_x86_64', cc: clang, cxx: clang++, config: --linkopt=-fuse-ld=lld }
-          - { name: 'MacOS 11 x86_64 LLVM+libc++', os: 'macos-11', platform: 'macosx_11_0_x86_64', cc: clang, cxx: clang++, config: --config=libc++ --config=macos }
-          - { name: 'MacOS 12 x86_64 LLVM+libc++', os: 'macos-12', platform: 'macosx_12_0_x86_64', cc: clang, cxx: clang++, config: --config=libc++ --config=macos }
-          - { name: 'MacOS 13 x86_64 LLVM+libc++', os: 'macos-13', platform: 'macosx_13_0_x86_64', cc: clang, cxx: clang++, config: --config=libc++ --config=macos }
-          - { name: 'MacOS 12 ARM64 LLVM+libc++', os: 'macos-12', platform: 'macosx_12_0_arm64', cc: clang, cxx: clang++,
+          - { name: 'Linux LLVM+libstdc++', os: 'ubuntu-22.04', cc: clang, cxx: clang++, config: --linkopt=-fuse-ld=lld }
+          - { name: 'MacOS 11 x86_64 LLVM+libc++', os: 'macos-11', cc: clang, cxx: clang++, config: --config=libc++ --config=macos }
+          - { name: 'MacOS 12 x86_64 LLVM+libc++', os: 'macos-12', cc: clang, cxx: clang++, config: --config=libc++ --config=macos }
+          - { name: 'MacOS 13 x86_64 LLVM+libc++', os: 'macos-13', cc: clang, cxx: clang++, config: --config=libc++ --config=macos }
+          - { name: 'MacOS 12 ARM64 LLVM+libc++', os: 'macos-12', cc: clang, cxx: clang++,
               config: --config=libc++ --config=macos_arm64 --repo_env=PY_PLATFORM_OVERRIDE=macosx_12_0_arm64 }
-          - { name: 'MacOS 13 ARM64 LLVM+libc++', os: 'macos-13', platform: 'macosx_13_0_arm64', cc: clang, cxx: clang++,
+          - { name: 'MacOS 13 ARM64 LLVM+libc++', os: 'macos-13', cc: clang, cxx: clang++,
               config: --config=libc++ --config=macos_arm64 --repo_env=PY_PLATFORM_OVERRIDE=macosx_13_0_arm64 }
-        py:
-          - { version: '3.8', interp: 'cp38', abi: 'cp38' }
-          - { version: '3.9', interp: 'cp39', abi: 'cp39' }
-          - { version: '3.10', interp: 'cp310', abi: 'cp310' }
-          - { version: '3.11', interp: 'cp311', abi: 'cp311' }
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
 
     env:
       CC:  ${{ matrix.cfg.cc }}
       CXX: ${{ matrix.cfg.cxx }}
+      WHEEL_NAME: ''
+      WHEEL_PATH: ''
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.py.version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Python Dependencies
         run: pip3 install --upgrade pip packaging
 
-      - name: Build for Python ${{ matrix.py.version }}
+      - name: Build for Python ${{ matrix.python-version }}
         run: bazel --bazelrc=.bazelrc build --compilation_mode=opt --dynamic_mode=off --config=luajit ${{ matrix.cfg.config }} //dmlab2d:dmlab2d_wheel
+
+      - name: Get built wheel name
+        working-directory: bazel-bin/dmlab2d
+        run: |
+          WHEEL_NAME="$(ls *.whl)"
+          WHEEL_PATH="$(pwd)/${WHEEL_NAME}"
+          echo WHEEL_PATH="${WHEEL_PATH}" >> "${GITHUB_ENV}"
+          echo WHEEL_NAME="${WHEEL_NAME}" >> "${GITHUB_ENV}"
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
@@ -78,6 +88,44 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload-url }}
-          asset_path: bazel-bin/dmlab2d/dmlab2d-1.0-${{ matrix.py.interp }}-${{ matrix.py.abi }}-${{ matrix.cfg.platform }}.whl
-          asset_name: dmlab2d-1.0-${{ matrix.py.interp }}-${{ matrix.py.abi }}-${{ matrix.cfg.platform }}.whl
+          asset_path: ${{ env.WHEEL_PATH }}
+          asset_name: ${{ env.WHEEL_NAME }}
           asset_content_type: application/zip
+
+      - name: Check wheel contents
+        run: |
+          pip install --upgrade check-wheel-contents
+          check-wheel-contents ${{ env.WHEEL_PATH }}
+
+      - name: Upload wheel as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: ${{ env.WHEEL_PATH }}
+          retention-days: 1
+
+  upload-wheel-to-pypi:
+    name: Upload wheel to Pypi
+    runs-on: ubuntu-latest
+    needs: build-wheel
+    timeout-minutes: 30
+
+    steps:
+      - name: Download all wheels
+        uses: actions/download-artifact@v3
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TESTPYPI_API_TOKEN }}
+          packages-dir: dist
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+
+      - name: Publish package to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist
+          verbose: true


### PR DESCRIPTION
Push wheels to PyPi on release [#20]

1. On the creation of a release, `make_wheel` uploads the wheels to pypi to enable installation using `pip install dmlab2d`.
2. Determines name of the written wheels without requiring version, abi, platform, etc. This allows version to be changed in `dmlab2d/BUILD` without having to also update `make_wheel.yml`.
3. `make_wheel` can be run manually but it will not update PyPi unless run at a tagged commit.
4. If the version number is not incremented, the release to pypi will fail (so the wheel version patch number will need to be bumped before on each release e.g. to 1.0.1, 1.0.0-dev, 1.0.0-alpha etc. (http://semver.org).
5. Once submitted this will not be functional until we add the pypi api tokens to the dmlab2d account.
