### PR TITLE
Add py_repositories() call

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -137,6 +137,10 @@ load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependen
 
 apple_support_dependencies()
 
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+
+py_repositories()
+
 python_repo(
     name = "python_system",
 )


### PR DESCRIPTION
I tried compiling a dmlab2d wheel for a CentOS 7-based compute cluster and encountered an error:
`ERROR: Skipping '//dmlab2d:dmlab2d_wheel': error loading package 'dmlab2d': at /root/.cache/bazel/_bazel_root/567cbe29eda1d897f010a5019ec89c95/external/rules_python/python/packaging.bzl:17:6: at /root/.cache/bazel/_bazel_root/567cbe29eda1d897f010a5019ec89c95/external/rules_python/python/py_binary.bzl:17:6: Unable to find package for @rules_python_internal//:rules_python_config.bzl: The repository '@rules_python_internal' could not be resolved: Repository '@rules_python_internal' is not defined.`

This error is specifically mentioned in the unreleased Python rules CHANGELOG:
https://github.com/bazelbuild/rules_python/blob/main/CHANGELOG.md

Building dmlab2d uses the Python rules repository in its current state. I added a call to the py_repositories() as mentioned in the change log, which fixed the error.


Details:
CentOS 7
Bazel 6.3.2 (and 5.4.1)